### PR TITLE
Fix #13 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata
+_includes/notes_graph.json

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 title:               My digital garden
 include:             ['_pages']
+baseurl:             /digital-garden-jekyll-template
 
 permalink:           pretty
 relative_permalinks: false

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,9 @@
 title:               My digital garden
 include:             ['_pages']
-baseurl:             /digital-garden-jekyll-template
+# You may need to change the base URL depending on your deploy configuration.
+# Specifically, when using GitHub Pages, the baseurl should point to where GitHub
+# Pages deploys your repository (which is usually the repository name).
+baseurl:             /
 
 permalink:           pretty
 relative_permalinks: false

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
 
   <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
 
-  <link rel="stylesheet" href="{{ site.baseurl }}/styles.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}styles.css">
 
   {% if page.excerpt %}
   <meta property="og:description" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}"/>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
 
   <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
 
-  <link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/styles.css">
 
   {% if page.excerpt %}
   <meta property="og:description" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}"/>


### PR DESCRIPTION
Fixes issue #13 

Chenge the `styles.css` link in `head.html` to include the base url of the site, to prevent problems when baseurl is changed or specified. 

This PR makes so that this repo is ready to use on github pages. Maybe consider making this a template?

Only problem is that people will have to specify their own specific baseurl.]