### PR TITLE
Update id generator function in Backlink Generator. Should now produc…

### DIFF
--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -66,6 +66,7 @@ class BidirectionalLinksGenerator < Jekyll::Generator
   end
 
   def note_id_from_note(note)
-    note.data['title'].gsub!(/\W+/, '').to_i(36).to_s
+    note.data['title'].gsub!(/\W+/, ' ')
+    note.data['title'].delete(' ').to_i(36).to_s
   end
 end

--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -66,6 +66,6 @@ class BidirectionalLinksGenerator < Jekyll::Generator
   end
 
   def note_id_from_note(note)
-    note.data['title'].to_i(36).to_s
+    note.data['title'].gsub!(/\W+/, '').to_i(36).to_s
   end
 end


### PR DESCRIPTION
…e unique values in titles with Symbols.

The default backlink generator script gets a note id using the following function:

``` ruby
def note_id_from_note(note)
    note.data['title'].to_i(36).to_s
  end
```

This falls over when a title contains anything outside of the range `[0-9A-Za-z]`. As such, any titles with symbols in must unique prior to the symbol - otherwise, notes will be produced with the same id.

As a stepping stone - I've updated the function to: 


``` ruby
def note_id_from_note(note)
    note.data['title'].gsub!(/\W+/, ' ')
    note.data['title'].delete(' ').to_i(36).to_s
  end
```

This should allow us to take more info than just the first word in title.