### PR TITLE
Add support for optional label in double-bracket links

### DIFF
--- a/_notes/your-first-note.md
+++ b/_notes/your-first-note.md
@@ -8,7 +8,14 @@ This is your first note. You'll find it in the [`notes/`](https://github.com/max
 
 ### Link syntax
 
-To link to another note, you can use Roam/wiki-style link syntax by wrapping a note's title (as defined in the note's front matter) in double brackets, like this: [[a note about cats]]. You may also use the note's filename without the extension in the brackets, like this: [[cats]]. If the Roam-style link does not point to a valid note's title, the double brackets will still be shown, like this: [[there is no note with this title]].
+To link to another note, you can use multiple syntaxes. The following four use the "double-bracket" notation (view the Markdown source file to see the underlying syntax).
+
+- Using the note title: [[a note about cats]]
+- Using the note's filename: [[cats]]
+- Using the note's title, with a label: [[A note about cats|link to the note about cats using the note title]]
+- Using the note's filename, with a label: [[cats|link to the note about cats using the note's filename]]
+
+In all cases, if the double-bracket link does not point to a valid note, the double brackets will still be shown, like this: [[there is no note that matches this link]].
 
 Alternatively, you can use regular [Markdown syntax](https://www.markdownguide.org/getting-started/) for links, with a relative link to the other note, like this: [this is a Markdown link to the note about cats](/cats){: .internal-link}. Don't forget to use the `.internal-link` class to make sure the link is styled as an internal link (without the little arrow).
 

--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -13,14 +13,34 @@ class BidirectionalLinksGenerator < Jekyll::Generator
     # anchor tag elements (<a>) with "internal-link" CSS class
     all_docs.each do |current_note|
       all_docs.each do |note_potentially_linked_to|
+        title_from_filename = File.basename(
+          note_potentially_linked_to.basename,
+          File.extname(note_potentially_linked_to.basename)
+        ).gsub('_', ' ').gsub('-', ' ').capitalize
+
+        # Replace double-bracketed links with label using note title
+        # [[A note about cats|this is a link to the note about cats]]
+        current_note.content = current_note.content.gsub(
+          /\[\[#{title_from_filename}\|(.+?)(?=\])\]\]/i,
+          "<a class='internal-link' href='#{note_potentially_linked_to.url}'>\\1</a>"
+        )
+
+        # Replace double-bracketed links with label using note filename
+        # [[cats|this is a link to the note about cats]]
+        current_note.content = current_note.content.gsub(
+          /\[\[#{note_potentially_linked_to.data['title']}\|(.+?)(?=\])\]\]/i,
+          "<a class='internal-link' href='#{note_potentially_linked_to.url}'>\\1</a>"
+        )
+
         # Replace double-bracketed links using note title
+        # [[a note about cats]]
         current_note.content = current_note.content.gsub(
           /\[\[(#{note_potentially_linked_to.data['title']})\]\]/i,
           "<a class='internal-link' href='#{note_potentially_linked_to.url}'>\\1</a>"
         )
 
         # Replace double-bracketed links using note filename
-        title_from_filename = File.basename(note_potentially_linked_to.basename, File.extname(note_potentially_linked_to.basename)).gsub('_', ' ').gsub('-', ' ').capitalize
+        # [[cats]]
         current_note.content = current_note.content.gsub(
           /\[\[(#{title_from_filename})\]\]/i,
           "<a class='internal-link' href='#{note_potentially_linked_to.url}'>\\1</a>"


### PR DESCRIPTION
Relates to https://github.com/maximevaillancourt/digital-garden-jekyll-template/issues/31

This pull request adds support for optional labels in double-bracket links.