### PR TITLE
Skip unnecessary rewrites of notes in `empty_front_matter_note_injector.rb`

### DIFF
--- a/_plugins/empty_front_matter_note_injector.rb
+++ b/_plugins/empty_front_matter_note_injector.rb
@@ -10,7 +10,9 @@ JEKYLL
 Jekyll::Hooks.register :site, :after_init do |site|
   Dir.glob(site.collections['notes'].relative_directory + '/**/*.md').each do |filename|
     raw_note_content = File.read(filename)
-    raw_note_content.prepend(EMPTY_FRONT_MATTER) unless raw_note_content.start_with?('---')
-    File.write(filename, raw_note_content)
+    unless raw_note_content.start_with?('---')
+      raw_note_content.prepend(EMPTY_FRONT_MATTER)
+      File.write(filename, raw_note_content)
+    end
   end
 end


### PR DESCRIPTION
Hi Maxime,

enjoy your template; thanks for sharing it!

I noticed that the plugin that inserts front matter to notes that don't have it, writes all notes to disk anyway, whether they already have it or not. That changes the modified time for the original Markdown note files in the _notes/ folder. At least for my workflow that meant that my editor could no longer meaningfully sort all notes by last modified date, because they all had the same time and date — that of the last time I generated the site with Jekyll.

Not sure if you accept pull requests, but if you do, here's a fix for that. Straightforward, just skipping the write step if the note already has front matter. I guess that also makes it run faster, but you'd have to have lots of notes for that to matter…

Have a great day,
Stefan