### PR TITLE
Update generator to include baseurl.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ exclude:             ['_includes/notes_graph.json']
 # You may need to change the base URL depending on your deploy configuration.
 # Specifically, when using GitHub Pages, the baseurl should point to where GitHub
 # Pages deploys your repository (which is usually the repository name).
-baseurl:             
+baseurl:             ''
 
 # If you are using a host that cannot resolve URLs that do
 # not end with .html (such as Neocities), set this to 'true'.

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ exclude:             ['_includes/notes_graph.json']
 # You may need to change the base URL depending on your deploy configuration.
 # Specifically, when using GitHub Pages, the baseurl should point to where GitHub
 # Pages deploys your repository (which is usually the repository name).
-baseurl:             /
+baseurl:             
 
 # If you are using a host that cannot resolve URLs that do
 # not end with .html (such as Neocities), set this to 'true'.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
 
   <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
 
-  <link rel="stylesheet" href="{{ site.baseurl }}styles.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/styles.css">
 
   {% if page.excerpt %}
   <meta property="og:description" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}"/>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,3 +1,3 @@
 <div>
-    <a class="internal-link" href="{{site.baseurl}}/"><b>{{ site.title }}</b></a>
+    <a class="internal-link" href="{{ site.baseurl }}/"><b>{{ site.title }}</b></a>
 </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,3 +1,3 @@
 <div>
-    <a class="internal-link" href="/"><b>{{ site.title }}</b></a>
+    <a class="internal-link" href="{{site.baseurl}}/"><b>{{ site.title }}</b></a>
 </div>

--- a/_layouts/note.html
+++ b/_layouts/note.html
@@ -22,7 +22,7 @@ layout: default
       <div style="display: grid; grid-gap: 1em; grid-template-columns: repeat(1fr);">
       {% for backlink in page.backlinks %}
         <div class="backlink-box">
-        <a class="internal-link" href="{{ backlink.url }}{%- if site.use_html_extension -%}.html{%- endif -%}">{{ backlink.title }}</a><br>
+        <a class="internal-link" href="{{site.baseurl}}{{ backlink.url }}{%- if site.use_html_extension -%}.html{%- endif -%}">{{ backlink.title }}</a><br>
         <div style="font-size: 0.9em">{{ backlink.excerpt | strip_html | truncatewords: 20 }}</div>
         </div>
       {% endfor %}

--- a/_layouts/note.html
+++ b/_layouts/note.html
@@ -22,7 +22,7 @@ layout: default
       <div style="display: grid; grid-gap: 1em; grid-template-columns: repeat(1fr);">
       {% for backlink in page.backlinks %}
         <div class="backlink-box">
-        <a class="internal-link" href="{{site.baseurl}}{{ backlink.url }}{%- if site.use_html_extension -%}.html{%- endif -%}">{{ backlink.title }}</a><br>
+        <a class="internal-link" href="{{ site.baseurl }}{{ backlink.url }}{%- if site.use_html_extension -%}.html{%- endif -%}">{{ backlink.title }}</a><br>
         <div style="font-size: 0.9em">{{ backlink.excerpt | strip_html | truncatewords: 20 }}</div>
         </div>
       {% endfor %}

--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -24,28 +24,28 @@ class BidirectionalLinksGenerator < Jekyll::Generator
         # [[A note about cats|this is a link to the note about cats]]
         current_note.content = current_note.content.gsub(
           /\[\[#{title_from_filename}\|(.+?)(?=\])\]\]/i,
-          "<a class='internal-link' href='#{note_potentially_linked_to.url}#{link_extension}'>\\1</a>"
+          "<a class='internal-link' href='#{site.baseurl}#{note_potentially_linked_to.url}#{link_extension}'>\\1</a>"
         )
 
         # Replace double-bracketed links with label using note filename
         # [[cats|this is a link to the note about cats]]
         current_note.content = current_note.content.gsub(
           /\[\[#{note_potentially_linked_to.data['title']}\|(.+?)(?=\])\]\]/i,
-          "<a class='internal-link' href='#{note_potentially_linked_to.url}#{link_extension}'>\\1</a>"
+          "<a class='internal-link' href='#{site.baseurl}#{note_potentially_linked_to.url}#{link_extension}'>\\1</a>"
         )
 
         # Replace double-bracketed links using note title
         # [[a note about cats]]
         current_note.content = current_note.content.gsub(
           /\[\[(#{note_potentially_linked_to.data['title']})\]\]/i,
-          "<a class='internal-link' href='#{note_potentially_linked_to.url}#{link_extension}'>\\1</a>"
+          "<a class='internal-link' href='#{site.baseurl}#{note_potentially_linked_to.url}#{link_extension}'>\\1</a>"
         )
 
         # Replace double-bracketed links using note filename
         # [[cats]]
         current_note.content = current_note.content.gsub(
           /\[\[(#{title_from_filename})\]\]/i,
-          "<a class='internal-link' href='#{note_potentially_linked_to.url}#{link_extension}'>\\1</a>"
+          "<a class='internal-link' href='#{site.baseurl}#{note_potentially_linked_to.url}#{link_extension}'>\\1</a>"
         )
       end
 
@@ -73,7 +73,7 @@ class BidirectionalLinksGenerator < Jekyll::Generator
       # Nodes: Graph
       graph_nodes << {
         id: note_id_from_note(current_note),
-        path: "#{current_note.url}#{link_extension}",
+        path: "#{site.baseurl}#{current_note.url}#{link_extension}",
         label: current_note.data['title'],
       } unless current_note.path.include?('_notes/index.html')
 


### PR DESCRIPTION
One of the breaking errors that I fixed in my install of this great repo was that all links generated by the ruby script didn't take into account the baseurl specified in the config file.

This ruby file corrects the error, although in the paths it might add one '/' too many. This hasn't caused me any issues, but should be considered.