### PR TITLE
Add option to open external links in new tab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 gem "jekyll", "~> 4.0"
 gem "jekyll-last-modified-at", git: "https://github.com/maximevaillancourt/jekyll-last-modified-at", branch: "add-support-for-files-in-git-submodules"
 gem "webrick", "~> 1.7"
+gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,10 +51,15 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    mini_portile2 (2.5.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)
     public_suffix (4.0.6)
+    racc (1.5.2)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -74,6 +79,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.0)
   jekyll-last-modified-at!
+  nokogiri
   webrick (~> 1.7)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,10 @@ baseurl:             ''
 # not end with .html (such as Neocities), set this to 'true'.
 use_html_extension:  false
 
+# Set to `true` to open non-internal links in new tabs, or
+# set to `false` to open non-internal links in current tab.
+open_external_links_in_new_tab: true
+
 permalink:           pretty
 relative_permalinks: false
 

--- a/_notes/your-first-note.md
+++ b/_notes/your-first-note.md
@@ -23,7 +23,13 @@ Since the Web is all about HTML, you can always use plain HTML if you want, like
 
 Of course, you can also link to external websites, like this: [this is a link to Wikipedia](https://wikipedia.org/). Again, you can use plain HTML if you prefer.
 
-**Note about static hosts**: if you use a static host that doesn't support URLs that don't end with `.html` (such as Neocities), try changing the `use_html_extension` value to `true` in the `_config.yml` file and restart the Jekyll server (or re-build the site). This adds a `.html` extension to note URLs and may resolve issues with links. If you're still having trouble, I recommend using Netlify to host your digital garden: it's free, easy to use, and fully supports this template's features out of the box.
+### Site configuration
+
+Some behavior is configurable by tweaking the `_config.yml` file.
+
+**`use_html_extension`**: if you use a static host that doesn't support URLs that don't end with `.html` (such as Neocities), try changing the `use_html_extension` value to `true` in the `_config.yml` file and restart the Jekyll server (or re-build the site). This adds a `.html` extension to note URLs and may resolve issues with links. If you're still having trouble, I recommend using Netlify to host your digital garden: it's free, easy to use, and fully supports this template's features out of the box.
+
+**`open_external_links_in_new_tab`**: when set to `true`, this makes external links open in new tabs. Set to `false` to open all links in the current tab.
 
 ### Automatic bi-directional links
 

--- a/_plugins/open_external_links_in_new_tab.rb
+++ b/_plugins/open_external_links_in_new_tab.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'nokogiri'
+
+# If the configuration sets `open_external_links_in_new_tab` to a truthy value,
+# add 'target=_blank' to anchor tags that don't have `internal-link` class
+Jekyll::Hooks.register [:pages, :notes], :post_convert do |doc|
+  open_external_links_in_new_tab = !!doc.site.config["open_external_links_in_new_tab"]
+
+  if open_external_links_in_new_tab
+    parsed_doc = Nokogiri::HTML(doc.content)
+    parsed_doc.css("a:not(.internal-link)").each do |link|
+      link.set_attribute('target', 'blank')
+    end
+    doc.content = parsed_doc.to_html
+  end
+end


### PR DESCRIPTION
This pull request adds a `open_external_links_in_new_tab` option, which automatically adds a `target="blank"` attribute to external links so that browsers open them in new tabs.