### PR TITLE
Treat footnotes as internal links

### DIFF
--- a/_notes/your-first-note.md
+++ b/_notes/your-first-note.md
@@ -4,7 +4,7 @@ title: Your first seed
 
 ### Welcome!
 
-This is your first note. You'll find it in the [`notes/`](https://github.com/maximevaillancourt/digital-garden-jekyll-template/tree/master/_notes) directory.
+This is your first note. You'll find it in the [`notes/`](https://github.com/maximevaillancourt/digital-garden-jekyll-template/tree/master/_notes) directory. 
 
 ### Link syntax
 
@@ -21,7 +21,9 @@ Alternatively, you can use regular [Markdown syntax](https://www.markdownguide.o
 
 Since the Web is all about HTML, you can always use plain HTML if you want, like this: <a class="internal-link" href="/cats">This is a link to the note about cats with HTML</a>.
 
-Of course, you can also link to external websites, like this: [this is a link to Wikipedia](https://wikipedia.org/). Again, you can use plain HTML if you prefer.
+Of course, you can also link to external websites, like this: [this is a link to Wikipedia](https://wikipedia.org/). Again, you can use plain HTML if you prefer. Footnotes are also supported and will be treated like internal links.[^1]
+
+[^1]: This is a footnote. For more information about using footnotes, check out the [Markdown Guide](https://www.markdownguide.org/extended-syntax/#footnotes).
 
 ### Site configuration
 
@@ -91,3 +93,7 @@ This digital garden template is free, open-source, and [available on GitHub here
 The easiest way to build your own digital garden based on this template is to read this [step-by-step guide explaining how to set this up from scratch](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll). If you need any help, my [DMs are open on Twitter (@vaillancourtmax)](https://twitter.com/vaillancourtmax). 👋
 
 Go forth, have fun, and learn new something every day! ✌️
+
+### Footnotes
+
+

--- a/_plugins/open_external_links_in_new_tab.rb
+++ b/_plugins/open_external_links_in_new_tab.rb
@@ -8,7 +8,7 @@ Jekyll::Hooks.register [:pages, :notes], :post_convert do |doc|
 
   if open_external_links_in_new_tab
     parsed_doc = Nokogiri::HTML(doc.content)
-    parsed_doc.css("a:not(.internal-link)").each do |link|
+    parsed_doc.css("a:not(.internal-link):not(.footnote):not(.reversefootnote)").each do |link|
       link.set_attribute('target', 'blank')
     end
     doc.content = parsed_doc.to_html

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -92,7 +92,9 @@ a {
     content: "↗";
     color: #aaaaaa;
   }
-  &.internal-link:after {
+  &.internal-link:after,
+  &.footnote:after,
+  &.reversefootnote:after {
     content: "";
   }
 }


### PR DESCRIPTION
Update to treat the classes .footnote and .reversefootnote the same as the internal-link class. With the current default settings, the classes are treated as external links and then a new page is opened when the footnote or reverse footnote link are clicked.

To test, add a footnote on a markdown page.[^1]

[^1]: this is a footnote