### PR TITLE
gsub -> gsub!

### DIFF
--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -25,28 +25,28 @@ class BidirectionalLinksGenerator < Jekyll::Generator
 
         # Replace double-bracketed links with label using note title
         # [[A note about cats|this is a link to the note about cats]]
-        current_note.content = current_note.content.gsub(
+        current_note.content.gsub!(
           /\[\[#{title_from_filename}\|(.+?)(?=\])\]\]/i,
           anchor_tag
         )
 
         # Replace double-bracketed links with label using note filename
         # [[cats|this is a link to the note about cats]]
-        current_note.content = current_note.content.gsub(
+        current_note.content.gsub!(
           /\[\[#{note_potentially_linked_to.data['title']}\|(.+?)(?=\])\]\]/i,
           anchor_tag
         )
 
         # Replace double-bracketed links using note title
         # [[a note about cats]]
-        current_note.content = current_note.content.gsub(
+        current_note.content.gsub!(
           /\[\[(#{note_potentially_linked_to.data['title']})\]\]/i,
           anchor_tag
         )
 
         # Replace double-bracketed links using note filename
         # [[cats]]
-        current_note.content = current_note.content.gsub(
+        current_note.content.gsub!(
           /\[\[(#{title_from_filename})\]\]/i,
           anchor_tag
         )
@@ -55,7 +55,7 @@ class BidirectionalLinksGenerator < Jekyll::Generator
       # At this point, all remaining double-bracket-wrapped words are
       # pointing to non-existing pages, so let's turn them into disabled
       # links by greying them out and changing the cursor
-      current_note.content = current_note.content.gsub(
+      current_note.content.gsub!(
         /\[\[(.*)\]\]/i, # match on the remaining double-bracket links
         <<~HTML.chomp    # replace with this HTML (\\1 is what was inside the brackets)
           <span title='There is no note that matches this link.' class='invalid-link'>


### PR DESCRIPTION
Feel free to ignore this pull request in case you were already aware of `!` and exerting a coding style opinion.

The following are equivalent, as far as I understand, so some chars can be deleted 🙂:

`current_note.content = current_note.content.gsub()` == `current_note.content.gsub!()`