### PR TITLE
Allow embedding tweets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,11 @@ use_html_extension:  false
 # set to `false` to open non-internal links in current tab.
 open_external_links_in_new_tab: true
 
+# Set to `true` to replace tweet URLs with Twitter embeds.
+# Note that doing so will negatively the reader's privacy
+# as their browser will communicate with Twitter's servers.
+embed_tweets: false
+
 permalink:           pretty
 relative_permalinks: false
 

--- a/_notes/your-first-note.md
+++ b/_notes/your-first-note.md
@@ -25,6 +25,14 @@ Of course, you can also link to external websites, like this: [this is a link to
 
 [^1]: This is a footnote. For more information about using footnotes, check out the [Markdown Guide](https://www.markdownguide.org/extended-syntax/#footnotes).
 
+### Tweet embedding
+
+Note: This behavior is disabled by default for privacy reasons. See "Site configuration" section below to enable it.
+
+You may include a tweet URL on its own line (like below), and it would be replaced with an official Twitter embed if the site configuration demands it.
+
+https://twitter.com/jack/status/20
+
 ### Site configuration
 
 Some behavior is configurable by tweaking the `_config.yml` file.
@@ -32,6 +40,8 @@ Some behavior is configurable by tweaking the `_config.yml` file.
 **`use_html_extension`**: if you use a static host that doesn't support URLs that don't end with `.html` (such as Neocities), try changing the `use_html_extension` value to `true` in the `_config.yml` file and restart the Jekyll server (or re-build the site). This adds a `.html` extension to note URLs and may resolve issues with links. If you're still having trouble, I recommend using Netlify to host your digital garden: it's free, easy to use, and fully supports this template's features out of the box.
 
 **`open_external_links_in_new_tab`**: when set to `true`, this makes external links open in new tabs. Set to `false` to open all links in the current tab.
+
+**`embed_tweets`**: when set to `true`, tweet URLs on their own lines will be replaced with a Twitter embed. Default value is `false`.
 
 ### Automatic bi-directional links
 

--- a/_plugins/embed_tweets.rb
+++ b/_plugins/embed_tweets.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class TweetEmbedGenerator < Jekyll::Generator
+  def generate(site)
+    return if !site.config["embed_tweets"]
+
+    all_notes = site.collections['notes'].docs
+    all_pages = site.pages
+    all_docs = all_notes + all_pages
+
+    all_docs.each do |current_note|
+      current_note.content.gsub!(
+        /^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)$/i,
+        <<~HTML
+          <blockquote class="twitter-tweet">
+           This tweet could not be embedded. <a href="#{'\0'}">View it on Twitter instead.</a>
+          </blockquote>
+          <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        HTML
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What are you trying to achieve?

This pull request adds a new site configuration flag to allow replacing tweet URLs on their own lines with official Twitter embeds. This behavior is however disabled by default for privacy reasons.

## Demo

Here's how it looks like when enabled and the browser is configured to allow external content:

![2021-06-16-234249_858x289_scrot](https://user-images.githubusercontent.com/8457808/122328113-96266800-cf1e-11eb-8948-a926aeb14511.png)

Here's how it looks like when enabled but the browser blocks external content:

![2021-06-16-234731_1182x279_scrot](https://user-images.githubusercontent.com/8457808/122328253-d980d680-cf1e-11eb-92cb-4711321fe257.png)

Here's how it looks like when disabled altogether (`embed_tweets: false` in `_config.yml`):

![2021-06-16-234854_847x140_scrot](https://user-images.githubusercontent.com/8457808/122328306-f1585a80-cf1e-11eb-86f8-537c992ce837.png)

cc @kolanuts