### PR TITLE
Highlight content wrapped with ==

### DIFF
--- a/_notes/your-first-note.md
+++ b/_notes/your-first-note.md
@@ -73,6 +73,8 @@ And of course, images look great:
 
 <img src="/assets/image.jpg"/>
 
+You can also ==highlight some content== by wrapping it with `==`.
+
 ### Code syntax highlighting
 
 You can add code blocks with full syntax color highlighting by wrapping code snippet in triple backticks and specifying the type of the code (`js`, `rb`, `sh`, etc.):

--- a/_plugins/markdown-highlighter.rb
+++ b/_plugins/markdown-highlighter.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Turns ==something== in Markdown to <mark>something</mark> in output HTML
+
+Jekyll::Hooks.register [:notes], :post_convert do |doc|
+  replace(doc)
+end
+
+Jekyll::Hooks.register [:pages], :post_convert do |doc|
+  # jekyll considers anything at the root as a page,
+  # we only want to consider actual pages
+  next unless doc.path.start_with?('_pages/')
+  replace(doc)
+end
+
+def replace(doc)
+  doc.content.gsub!(/==+(\w(.*?)?[^ .=]?)==+/, "<mark>\\1</mark>")
+end


### PR DESCRIPTION
Fixes https://github.com/maximevaillancourt/digital-garden-jekyll-template/issues/73

This pull request adds highlighting for content wrapped with `==`.

Input:
```
You can also ==highlight some content== by wrapping it with `==`.
```

Output:
![2021-08-23-194015_549x67_scrot](https://user-images.githubusercontent.com/8457808/130533022-6f176511-deac-426f-82fd-9fcdcb74b32c.png)
