### PR TITLE
Fix links to notes in footnotes

### DIFF
--- a/_notes/your-first-note.md
+++ b/_notes/your-first-note.md
@@ -21,9 +21,10 @@ Alternatively, you can use regular [Markdown syntax](https://www.markdownguide.o
 
 Since the Web is all about HTML, you can always use plain HTML if you want, like this: <a class="internal-link" href="/cats">This is a link to the note about cats with HTML</a>.
 
-Of course, you can also link to external websites, like this: [this is a link to Wikipedia](https://wikipedia.org/). Again, you can use plain HTML if you prefer. Footnotes are also supported and will be treated like internal links.[^1]
+Of course, you can also link to external websites, like this: [this is a link to Wikipedia](https://wikipedia.org/). Again, you can use plain HTML if you prefer. Footnotes are also supported and will be treated like internal links.[^1] You can point to other notes in your footnotes.[^2]
 
 [^1]: This is a footnote. For more information about using footnotes, check out the [Markdown Guide](https://www.markdownguide.org/extended-syntax/#footnotes).
+[^2]: This is another footnote that links to the note about [[cats]]. You may also point to [[notes that do not exist]] if you wish.
 
 ### Tweet embedding
 
@@ -103,7 +104,3 @@ This digital garden template is free, open-source, and [available on GitHub here
 The easiest way to build your own digital garden based on this template is to read this [step-by-step guide explaining how to set this up from scratch](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll). If you need any help, my [DMs are open on Twitter (@vaillancourtmax)](https://twitter.com/vaillancourtmax). 👋
 
 Go forth, have fun, and learn new something every day! ✌️
-
-### Footnotes
-
-

--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -57,7 +57,7 @@ class BidirectionalLinksGenerator < Jekyll::Generator
       # links by greying them out and changing the cursor
       current_note.content = current_note.content.gsub(
         /\[\[([^\]]+)\]\]/i, # match on the remaining double-bracket links
-        <<~HTML.chomp    # replace with this HTML (\\1 is what was inside the brackets)
+        <<~HTML.delete("\n") # replace with this HTML (\\1 is what was inside the brackets)
           <span title='There is no note that matches this link.' class='invalid-link'>
             <span class='invalid-link-brackets'>[[</span>
             \\1


### PR DESCRIPTION
This fixes https://github.com/maximevaillancourt/digital-garden-jekyll-template/issues/83.

The newlines in the inserted string would break Jekyll's way of generating footnotes with wikilinks in them.

The fix is to remove these newlines to ensure Jekyll doesn't mess with the inserted HTML.