### PR TITLE
fix: missing .id from nodes

### DIFF
--- a/_includes/notes_graph.html
+++ b/_includes/notes_graph.html
@@ -60,7 +60,7 @@
         let weight =
           3 *
           Math.sqrt(
-            linksData.filter((l) => l.source === el.id || l.target === el.id)
+            linksData.filter((l) => l.source.id === el.id || l.target.id === el.id)
               .length + 1
           );
         if (weight < MINIMAL_NODE_SIZE) {

--- a/_includes/notes_graph.html
+++ b/_includes/notes_graph.html
@@ -151,7 +151,7 @@
       }
 
       for (const edge of next) {
-        if (!set.has(`${edge.source}-${edge.target}`)) {
+        if (!set.has(`${edge.source.id}-${edge.target.id}`)) {
           return false;
         }
       }


### PR DESCRIPTION
# What it is
We should compare the `id` attribute instead of the node object. 

# Why we need this
These bugs casues:
1. all nodes to have the same weights.
2. edges to be duplicated? (i haven't spent time trying to see the effect of this)
