### PR TITLE
allow for using - and _ in the links

### DIFF
--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -18,7 +18,7 @@ class BidirectionalLinksGenerator < Jekyll::Generator
         title_from_filename = File.basename(
           note_potentially_linked_to.basename,
           File.extname(note_potentially_linked_to.basename)
-        ).gsub('_', ' ').gsub('-', ' ').capitalize
+        ).gsub('_', '[ _]').gsub('-', '[ -]').capitalize
 
         new_href = "#{site.baseurl}#{note_potentially_linked_to.url}#{link_extension}"
         anchor_tag = "<a class='internal-link' href='#{new_href}'>\\1</a>"

--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -15,7 +15,7 @@ class BidirectionalLinksGenerator < Jekyll::Generator
     # anchor tag elements (<a>) with "internal-link" CSS class
     all_docs.each do |current_note|
       all_docs.each do |note_potentially_linked_to|
-        title_from_filename = File.basename(
+        note_title_regexp_pattern = File.basename(
           note_potentially_linked_to.basename,
           File.extname(note_potentially_linked_to.basename)
         ).gsub('_', '[ _]').gsub('-', '[ -]').capitalize


### PR DESCRIPTION
Hey.
I created quick fix for links that may have "-" or "_" in them.
See my page: https://www.ksidelta.com/management-3-0
And the link: Presentation - Being Explicit

I did it because I integrated obsidian with this digital garden and obsidian allows for "-" in file names.

Please reject this PR if it doesn't contribute to the direction you have in mind.