### PR TITLE
Add support for non-latin note titles

### DIFF
--- a/_notes/your-first-note.md
+++ b/_notes/your-first-note.md
@@ -15,6 +15,8 @@ To link to another note, you can use multiple syntaxes. The following four use t
 - Using the note's title, with a label: [[A note about cats|link to the note about cats using the note title]]
 - Using the note's filename, with a label: [[cats|link to the note about cats using the note's filename]]
 
+Non-latin languages are supported too: [[안녕하세요]].
+
 In all cases, if the double-bracket link does not point to a valid note, the double brackets will still be shown, like this: [[there is no note that matches this link]].
 
 Alternatively, you can use regular [Markdown syntax](https://www.markdownguide.org/getting-started/) for links, with a relative link to the other note, like this: [this is a Markdown link to the note about cats](/cats){: .internal-link}. Don't forget to use the `.internal-link` class to make sure the link is styled as an internal link (without the little arrow).

--- a/_notes/안녕하세요.md
+++ b/_notes/안녕하세요.md
@@ -1,0 +1,6 @@
+---
+title: 안녕하세요
+---
+
+This template supports any language. Come as you are! :)
+

--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -104,11 +104,6 @@ class BidirectionalLinksGenerator < Jekyll::Generator
   end
 
   def note_id_from_note(note)
-    note.data['title']
-      .dup
-      .gsub(/\W+/, ' ')
-      .delete(' ')
-      .to_i(36)
-      .to_s
+    note.data['title'].bytes.join
   end
 end


### PR DESCRIPTION
This pull request fixes https://github.com/maximevaillancourt/digital-garden-jekyll-template/issues/100 by adding support for non-latin note titles.