### PR TITLE
Allow using `-` and `_` in links

### DIFF
--- a/_notes/your-first-note.md
+++ b/_notes/your-first-note.md
@@ -17,6 +17,8 @@ To link to another note, you can use multiple syntaxes. The following four use t
 
 Non-latin languages are supported too: [[안녕하세요]].
 
+Dashes and underscores in file names are supported, and may be omitted in the bracket link syntax. As an example, the `your-first-note.md` file can be linked to with [[your first note]] or [[your-first-note]], or even [[yOuR-FiRsT Note]].
+
 In all cases, if the double-bracket link does not point to a valid note, the double brackets will still be shown, like this: [[there is no note that matches this link]].
 
 Alternatively, you can use regular [Markdown syntax](https://www.markdownguide.org/getting-started/) for links, with a relative link to the other note, like this: [this is a Markdown link to the note about cats](/cats){: .internal-link}. Don't forget to use the `.internal-link` class to make sure the link is styled as an internal link (without the little arrow).

--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -15,10 +15,12 @@ class BidirectionalLinksGenerator < Jekyll::Generator
     # anchor tag elements (<a>) with "internal-link" CSS class
     all_docs.each do |current_note|
       all_docs.each do |note_potentially_linked_to|
-        title_from_filename = Regexp.escape(File.basename(
-          note_potentially_linked_to.basename,
-          File.extname(note_potentially_linked_to.basename)
-        ).gsub('_', ' ').gsub('-', ' ').capitalize)
+        note_title_regexp_pattern = Regexp.escape(
+          File.basename(
+            note_potentially_linked_to.basename,
+            File.extname(note_potentially_linked_to.basename)
+          )
+        ).gsub('\_', '[ _]').gsub('\-', '[ -]').capitalize
 
         title_from_data = note_potentially_linked_to.data['title']
         if title_from_data
@@ -31,7 +33,7 @@ class BidirectionalLinksGenerator < Jekyll::Generator
         # Replace double-bracketed links with label using note title
         # [[A note about cats|this is a link to the note about cats]]
         current_note.content.gsub!(
-          /\[\[#{title_from_filename}\|(.+?)(?=\])\]\]/i,
+          /\[\[#{note_title_regexp_pattern}\|(.+?)(?=\])\]\]/i,
           anchor_tag
         )
 
@@ -52,7 +54,7 @@ class BidirectionalLinksGenerator < Jekyll::Generator
         # Replace double-bracketed links using note filename
         # [[cats]]
         current_note.content.gsub!(
-          /\[\[(#{title_from_filename})\]\]/i,
+          /\[\[(#{note_title_regexp_pattern})\]\]/i,
           anchor_tag
         )
       end


### PR DESCRIPTION
Supersedes https://github.com/maximevaillancourt/digital-garden-jekyll-template/pull/95.

Allows links to include underscores and hyphens.