### PR TITLE
Use _blank for the target

### DIFF
--- a/_plugins/open_external_links_in_new_tab.rb
+++ b/_plugins/open_external_links_in_new_tab.rb
@@ -21,7 +21,7 @@ def convert_links(doc)
   if open_external_links_in_new_tab
     parsed_doc = Nokogiri::HTML(doc.content)
     parsed_doc.css("a:not(.internal-link):not(.footnote):not(.reversefootnote)").each do |link|
-      link.set_attribute('target', 'blank')
+      link.set_attribute('target', '_blank')
     end
     doc.content = parsed_doc.to_html
   end


### PR DESCRIPTION
Some browsers might interpret "blank" as a named frame. You might want to consider using the browser standard _blank

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target