### PR TITLE
code block left alignment

### DIFF
--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -6,6 +6,9 @@
   font-size: 0.9em;
   overflow: auto;
   margin: 1em -1em;
+  code{
+    padding: 0;
+  }
 }
 
 div.highlight {


### PR DESCRIPTION
before:
<img width="210" alt="image" src="https://user-images.githubusercontent.com/23608642/175961046-ff77688f-aa91-4219-9386-0da8a01b210a.png">

after:
<img width="179" alt="image" src="https://user-images.githubusercontent.com/23608642/175961750-92a1c1a3-4442-4a8f-b1d1-85392195d7c0.png">


now `code` tag is padded, so the `code` of `highlight` has no left alignment, I think it would be better to be consistent.