### PR TITLE
Fix issue with full HTML + DOCTYPE being inserted

### DIFF
--- a/_plugins/open_external_links_in_new_tab.rb
+++ b/_plugins/open_external_links_in_new_tab.rb
@@ -23,6 +23,6 @@ def convert_links(doc)
     parsed_doc.css("a:not(.internal-link):not(.footnote):not(.reversefootnote)").each do |link|
       link.set_attribute('target', '_blank')
     end
-    doc.content = parsed_doc.to_html
+    doc.content = parsed_doc.inner_html
   end
 end


### PR DESCRIPTION
Closes issue #116

Use `inner_html` instead of `to_html` to prevent Nokogiri from wrapping the content in HTML DOCTYPE