### PR TITLE
Show most recent notes on homepage

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -15,6 +15,17 @@ This digital garden template is free, open-source, and [available on GitHub here
 
 The easiest way to get started is to read this [step-by-step guide explaining how to set this up from scratch](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll).
 
+<strong>Recently updated notes</strong>
+
+<ul>
+  {% assign recent_notes = site.notes | sort: "last_modified_at_timestamp" | reverse %}
+  {% for note in recent_notes | limit: 5 %}
+    <li>
+      {{ note.last_modified_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ note.url }}">{{ note.title }}</a>
+    </li>
+  {% endfor %}
+</ul>
+
 <style>
   .wrapper {
     max-width: 46em;

--- a/_plugins/last_modified_at_generator.rb
+++ b/_plugins/last_modified_at_generator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'pathname'
+require 'jekyll-last-modified-at'
+
+module Recents
+  # Generate change information for all markdown pages
+  class Generator < Jekyll::Generator
+    def generate(site)
+      items = site.collections['notes'].docs
+      items.each do |page|
+        timestamp = Jekyll::LastModifiedAt::Determinator.new(site.source, page.path, '%FT%T%:z').to_s
+        page.data['last_modified_at_timestamp'] = timestamp
+      end
+    end
+  end
+end


### PR DESCRIPTION
As asked here: https://github.com/maximevaillancourt/digital-garden-jekyll-template/discussions/146#discussion-4762676.

Now adding to the home page for everyone to use if they want to.

![image](https://user-images.githubusercontent.com/8457808/215617714-6c9bf1af-2604-4658-b672-eb366c2387e9.png)
