### PR TITLE
Fix Liquid syntax error

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -19,7 +19,7 @@ The easiest way to get started is to read this [step-by-step guide explaining ho
 
 <ul>
   {% assign recent_notes = site.notes | sort: "last_modified_at_timestamp" | reverse %}
-  {% for note in recent_notes | limit: 5 %}
+  {% for note in recent_notes limit: 5 %}
     <li>
       {{ note.last_modified_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ note.url }}">{{ note.title }}</a>
     </li>


### PR DESCRIPTION
When generating using this template, the following warning appears:

`Liquid Warning: Liquid syntax error (line 15): Expected end_of_string but found pipe in "note in recent_notes | limit: 5" in _pages/index.md`

This happens regardless of the amount of notes that exist.

This PR fixes this warning, while not affecting the functionality.

--

Thank you for this template, it is very well thought out. :heart: