### PR TITLE
Fix Exception when running Ruby 3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
+    liquid (4.0.4)
     listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)


### PR DESCRIPTION
Liquid 4.0.3 does not fully support Ruby 3.2. See: https://github.com/jekyll/jekyll/issues/9233

This PR upgrades Liquid to 4.0.4, fixing this issue while still maintaining complete backwards compatibility.