### PR TITLE
Fix the note graph's layout

### DIFF
--- a/_includes/notes_graph.html
+++ b/_includes/notes_graph.html
@@ -32,6 +32,11 @@
     border-radius: 4px;
     height: auto;
   }
+  
+  #graph-wrapper > svg {
+    max-width: 100%;
+    display: block;
+  }
 </style>
 
 <div id="graph-wrapper">


### PR DESCRIPTION
- Its "hitbox" actually extends to the right of the page, meaning that scrolling on the right edge of the page would override the page scroll and instead zoom the graph
- An annoying small bottom margin is present, adding `display: block;` fixes it.  
*(It might be due to some obscure `vertical-align` or `line-height`, but setting its display to block does not harm whatsoever and fixes the issue)*