### PR TITLE
Actually prevent Markdown highlight conflict

### DIFF
--- a/_includes/notes_graph.html
+++ b/_includes/notes_graph.html
@@ -71,7 +71,7 @@
             let weight =
               3 *
               Math.sqrt(
-                linksData.filter((l) => l.source.id == el.id || l.target.id == el.id)
+                linksData.filter((l) => l.source.id === el.id || l.target.id === el.id)
                   .length + 1
               );
             if (weight < MINIMAL_NODE_SIZE) {
@@ -111,7 +111,7 @@
           });
 
           link.attr("stroke-width", (link_d) => {
-            if (link_d.source.id == d.id || link_d.target.id == d.id) {
+            if (link_d.source.id === d.id || link_d.target.id === d.id) {
               return STROKE * 4;
             }
             return STROKE;

--- a/_notes/your-first-note.md
+++ b/_notes/your-first-note.md
@@ -102,7 +102,8 @@ You can add code blocks with full syntax color highlighting by wrapping code sni
 
 ```js
 // Here's a bit of JavaScript:
-console.log('hello!')
+if (a === b || c == d)
+  console.log('hello!')
 ```
 
 ```rb

--- a/_plugins/markdown-highlighter.rb
+++ b/_plugins/markdown-highlighter.rb
@@ -14,5 +14,5 @@ Jekyll::Hooks.register [:pages], :pre_render do |doc|
 end
 
 def replace(doc)
-  doc.content.gsub!(/==+([^ ](.*?)?[^ .=]?)==+/, "<mark>\\1</mark>")
+  doc.content.gsub!(/==+([^ ](.*?)?[^ .=])==+/, "<mark>\\1</mark>")
 end

--- a/_plugins/markdown-highlighter.rb
+++ b/_plugins/markdown-highlighter.rb
@@ -2,11 +2,11 @@
 
 # Turns ==something== in Markdown to <mark>something</mark> in output HTML
 
-Jekyll::Hooks.register [:notes], :post_convert do |doc|
+Jekyll::Hooks.register [:notes], :pre_render do |doc|
   replace(doc)
 end
 
-Jekyll::Hooks.register [:pages], :post_convert do |doc|
+Jekyll::Hooks.register [:pages], :pre_render do |doc|
   # jekyll considers anything at the root as a page,
   # we only want to consider actual pages
   next unless doc.path.start_with?('_pages/')


### PR DESCRIPTION
Fix #148 (for real)

- JavaScript code snippet renders as expected
- Markdown highlights render as expected
- No error in the console

<img width="1512" alt="Capture d’écran, le 2023-03-19 à 13 08 54" src="https://user-images.githubusercontent.com/8457808/226194349-1d90c877-d20a-4321-b2b1-940e7ae7af0a.png">