### PR TITLE
Fix string delimiters being unstyled in code blocks

### DIFF
--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -68,6 +68,7 @@ div.highlight {
 .highlight .sx { color: #d14 } /* Literal.String.Other */
 .highlight .sr { color: #009926 } /* Literal.String.Regex */
 .highlight .s1 { color: #d14 } /* Literal.String.Single */
+.highlight .dl { color: #d14 } /* Literal.String.Delimiter */
 .highlight .ss { color: #990073 } /* Literal.String.Symbol */
 .highlight .bp { color: #999999 } /* Name.Builtin.Pseudo */
 .highlight .vc { color: #008080 } /* Name.Variable.Class */


### PR DESCRIPTION
For some reason, single quotation marks are marked as `.dl` and separate from the actual string (here, `.s1`); but double quotation marks are part of the same element as the string itself (`.s2`)

This PR fixes this absolutely minor detail that probably nobody ever noticed :joy:

![image](https://user-images.githubusercontent.com/17962248/226222394-0f5f31cd-28d1-46f7-a1a4-b68cb627461b.png)

Fixed:
![image](https://user-images.githubusercontent.com/17962248/226222674-d7b10eac-3c62-45c6-ab64-ff5d2f71f757.png)
