### PR TITLE
Easy Github Pages

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,64 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v2
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/404.html
+++ b/404.html
@@ -7,5 +7,5 @@ id: "not-found"
 
 <div>
   <h1>Oops, that's a 404. 🙈</h1>
-  <p>Looks like this page doesn't exist. <a href="/">Return home</a> to get a fresh start.</p>
+  <p>Looks like this page doesn't exist. <a href="{{ site.baseurl }}/">Return home</a> to get a fresh start.</p>
 </div>

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Preview the template here: https://digital-garden-jekyll-template.netlify.app/
 <img width="1522" alt="Screen Shot 2020-05-19 at 23 05 46" src="https://user-images.githubusercontent.com/8457808/82400515-7d026d80-9a25-11ea-83f1-3b9cb8347e07.png">
 
 ## A note about GitHub Pages
-
-**Update (January 2023)**: it seems that GitHub Pages supports custom plugins now, thanks to GitHub Actions ([view relevant discussion](https://github.com/maximevaillancourt/digital-garden-jekyll-template/discussions/144)).
+> [!NOTE]  
+> **Update (January 2023)**: it seems that GitHub Pages supports custom plugins now, thanks to GitHub Actions ([view relevant discussion](https://github.com/maximevaillancourt/digital-garden-jekyll-template/discussions/144)). 
 
 GitHub Pages only partially supports this template: to power the interactive notes graph, this template uses a custom Jekyll plugin to generate the graph data in [`notes_graph.json`](https://github.com/maximevaillancourt/digital-garden-jekyll-template/blob/7ac331a4113bac77c993856562acc2bfbde9f2f7/_plugins/bidirectional_links_generator.rb#L102), and [GitHub Pages doesn't support custom Jekyll plugins](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#plugins).
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,6 @@ title:               My digital garden
 include:             ['_pages']
 exclude:             ['_includes/notes_graph.json']
 # You may need to change the base URL depending on your deploy configuration.
-# Specifically, when using GitHub Pages, the baseurl should point to where GitHub
-# Pages deploys your repository (which is usually the repository name).
 baseurl:             ''
 
 # If you are using a host that cannot resolve URLs that do

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,1 +1,1 @@
-This is the footer. Include anything you'd like here, like a link to an <a class="internal-link" href="/about">About</a> page.
+This is the footer. Include anything you'd like here, like a link to an <a class="internal-link" href="{{ site.baseurl }}/about">About</a> page.

--- a/_notes/your-first-note.md
+++ b/_notes/your-first-note.md
@@ -46,7 +46,7 @@ You may embed media files within a note using HTML5 media tags. Here's an exampl
 
 "Jazzy Frenchy" by Benjamin Tissot from bensound.com
 <audio controls>
-  <source src="/assets/jazzyfrenchy.mp3" type="audio/mpeg">
+  <source src="{{ site.baseurl }}/assets/jazzyfrenchy.mp3" type="audio/mpeg">
   Your browser does not support the audio element.
 </audio>
 
@@ -90,7 +90,7 @@ If you'd like to quote other people, consider using quote blocks:
 
 And of course, images look great:
 
-<img src="/assets/image.jpg"/>
+<img src="{{ site.baseurl }}/assets/image.jpg"/>
 
 You can also ==highlight some content== by wrapping it with `==`.
 

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -21,7 +21,7 @@ The easiest way to get started is to read this [step-by-step guide explaining ho
   {% assign recent_notes = site.notes | sort: "last_modified_at_timestamp" | reverse %}
   {% for note in recent_notes limit: 5 %}
     <li>
-      {{ note.last_modified_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ note.url }}">{{ note.title }}</a>
+      {{ note.last_modified_at | date: "%Y-%m-%d" }} — <a class="internal-link" href="{{ site.baseurl }}/{{ note.url }}">{{ note.title }}</a>
     </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
- fix recent notes url
- allow digital garden to be deployed and hosted on github pages!
- fix url for assets
- remove misleading instructions
- clarify the new from the old text on the README using the new NOTE highlight box
- fix footer link as well
- fix 404 as well
- this fixes #176 
- this fixes #58 