### PR TITLE
Fixed issue related to jekyll-last-modified-at

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "jekyll", "~> 4.3"
-gem "jekyll-last-modified-at", git: "https://github.com/maximevaillancourt/jekyll-last-modified-at", branch: "add-support-for-files-in-git-submodules"
+gem "jekyll-last-modified-at", git: "https://github.com/maximevaillancourt/jekyll-last-modified-at"
 gem "webrick", "~> 1.8"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,9 @@
 GIT
   remote: https://github.com/maximevaillancourt/jekyll-last-modified-at
-  revision: e0c918691db625401ef5850a030da59d0124d356
-  branch: add-support-for-files-in-git-submodules
+  revision: 3052cbe5fdf550dd1e85ed8eb7ec7a5595cd9f1d
   specs:
-    jekyll-last-modified-at (1.3.0)
+    jekyll-last-modified-at (1.3.2)
       jekyll (>= 3.7, < 5.0)
-      posix-spawn (~> 0.3.9)
 
 GEM
   remote: https://rubygems.org/
@@ -62,7 +60,6 @@ GEM
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    posix-spawn (0.3.15)
     public_suffix (6.0.1)
     racc (1.8.0)
     rake (13.2.1)


### PR DESCRIPTION
The specification of the branch associated with jekyll-last-modified-at did not allow the website to be built due to issues with posix-spawn.