### PR TITLE
Parse document as fragment

### DIFF
--- a/_plugins/open_external_links_in_new_tab.rb
+++ b/_plugins/open_external_links_in_new_tab.rb
@@ -19,7 +19,7 @@ def convert_links(doc)
   open_external_links_in_new_tab = !!doc.site.config["open_external_links_in_new_tab"]
 
   if open_external_links_in_new_tab
-    parsed_doc = Nokogiri::HTML(doc.content)
+    parsed_doc = Nokogiri::HTML::DocumentFragment.parse(doc.content)
     parsed_doc.css("a:not(.internal-link):not(.footnote):not(.reversefootnote)").each do |link|
       link.set_attribute('target', '_blank')
     end


### PR DESCRIPTION
Prevents the creation of unnecessary `<html>` and `<body>` tags when `open_external_links_in_new_tab` config option is set to `true`.

May fix #196.