### PR TITLE
Ignore current note when generating backlinks

### DIFF
--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -77,7 +77,7 @@ class BidirectionalLinksGenerator < Jekyll::Generator
     all_notes.each do |current_note|
       # Nodes: Jekyll
       notes_linking_to_current_note = all_notes.filter do |e|
-        e.content.include?(current_note.url)
+        e.url != current_note.url && e.content.include?(current_note.url)
       end
 
       # Nodes: Graph


### PR DESCRIPTION
If the current note has a link to an image, a bad backlink will be generated from the given note to itself. This change prevents the current note from creating a backlink to itself for any reason.

This can be seen in the netlify sample site: https://digital-garden-jekyll-template.netlify.app/your-first-note
