### PR TITLE
Added support for .html extension in canonical links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ _includes/notes_graph.json
 
 # Obsidian config
 .obsidian/
+
+# System files
+.DS_Store
+.Thumbs.db

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
 <head>
   <meta charset="UTF-8">
 
-  <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
+  <link rel="canonical" href="{{ site.url }}{{ page.url }}{%- if page.url != '/' and site.use_html_extension -%}.html{%- endif -%}" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 


### PR DESCRIPTION
The head.html template now checks for the `use_html_extension` variable. If it's set and the current page is not the root (/), the .html extension is appended to the canonical link.

Tip: for correct sitemap I fork and hack [jekyll_sitemap](https://github.com/e41q/jekyll-sitemap) for links with .html at the end.

And add `.DS_Store` `.Thumbs.db` to `.gitignore`.