### PR TITLE
Solved Deprecation Warning for Dart Sass 3.0.0 [Enhancement]

### DIFF
--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -1,8 +1,9 @@
+@use "sass:color";
 $color-primary: hsl(0, 0%, 10%);
 $color-text: hsl(0, 0%, 20%);
 $color-subtext: hsl(0, 0%, 30%);
 $color-border: hsl(0, 0%, 85%);
-$color-box-background: mix($color-primary, white, 4%);
+$color-box-background: color.mix($color-primary, white, 4%);
 $border-radius: 4px;
 $font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
   sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
@@ -32,7 +33,7 @@ time {
 footer {
   margin: 2em 0;
   font-size: 0.8em;
-  color: mix($color-text, white, 80%);
+  color: color.mix($color-text, white, 80%);
   padding-top: 1em;
 }
 

--- a/styles.scss
+++ b/styles.scss
@@ -1,6 +1,6 @@
 ---
 ---
 
-@import "../_sass/normalize";
-@import "../_sass/code";
-@import "../_sass/style";
+@use "../_sass/normalize" as *;
+@use "../_sass/code" as *;
+@use "../_sass/style" as *;


### PR DESCRIPTION
Hello, 

The current style for importing _sass modules (in `styles.scss`) will be deprecated soon, resulting in the following deprecation warning. There are multiple such warnings. I updated the importing style to `@use` to get rid of these warnings.

This will prevent breaking of code when the support is completely stopped.

```
Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
More info and automated migrator: https://sass-lang.com/d/import

  ╷
1 │ @import "../_sass/normalize";
  │         ^^^^^^^^^^^^^^^^^^^^
  ╵
    ~/digital-garden-jekyll-template/styles.scss 1:9  root stylesheet
```